### PR TITLE
Fix: Null-Label Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_role"></a> [access\_role](#module\_access\_role) | cloudposse/label/null | 0.25.0 |
-| <a name="module_prometheus_policy_label"></a> [prometheus\_policy\_label](#module\_prometheus\_policy\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_account_access_policy_label"></a> [account\_access\_policy\_label](#module\_account\_access\_policy\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_vpc_endpoint_policy"></a> [vpc\_endpoint\_policy](#module\_vpc\_endpoint\_policy) | cloudposse/iam-policy/aws | v2.0.1 |
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_role"></a> [access\_role](#module\_access\_role) | cloudposse/label/null | 0.25.0 |
+| <a name="module_prometheus_policy_label"></a> [prometheus\_policy\_label](#module\_prometheus\_policy\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_vpc_endpoint_policy"></a> [vpc\_endpoint\_policy](#module\_vpc\_endpoint\_policy) | cloudposse/iam-policy/aws | v2.0.1 |
 

--- a/cross-account-role.tf
+++ b/cross-account-role.tf
@@ -58,7 +58,7 @@ module "account_access_policy_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 
-  enabled = local.prometheus_policy_enabled
+  enabled = local.access_role_enabled
 
   attributes = ["aps"]
 

--- a/cross-account-role.tf
+++ b/cross-account-role.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role" "account_access" {
   })
 
   inline_policy {
-    name   = module.prometheus_policy_label.id
+    name   = module.account_access_policy_label.id
     policy = data.aws_iam_policy_document.aps[0].json
   }
 }
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "aps" {
   }
 }
 
-module "prometheus_policy_label" {
+module "account_access_policy_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
 

--- a/cross-account-role.tf
+++ b/cross-account-role.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role" "account_access" {
   })
 
   inline_policy {
-    name   = "${module.this.id}-aps"
+    name   = module.prometheus_policy_label.id
     policy = data.aws_iam_policy_document.aps[0].json
   }
 }
@@ -52,4 +52,15 @@ data "aws_iam_policy_document" "aps" {
     ]
     resources = ["*"]
   }
+}
+
+module "prometheus_policy_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  enabled = local.prometheus_policy_enabled
+
+  attributes = ["aps"]
+
+  context = module.this.context
 }

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,6 +17,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_role"></a> [access\_role](#module\_access\_role) | cloudposse/label/null | 0.25.0 |
+| <a name="module_prometheus_policy_label"></a> [prometheus\_policy\_label](#module\_prometheus\_policy\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_vpc_endpoint_policy"></a> [vpc\_endpoint\_policy](#module\_vpc\_endpoint\_policy) | cloudposse/iam-policy/aws | v2.0.1 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,7 +17,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_role"></a> [access\_role](#module\_access\_role) | cloudposse/label/null | 0.25.0 |
-| <a name="module_prometheus_policy_label"></a> [prometheus\_policy\_label](#module\_prometheus\_policy\_label) | cloudposse/label/null | 0.25.0 |
+| <a name="module_account_access_policy_label"></a> [account\_access\_policy\_label](#module\_account\_access\_policy\_label) | cloudposse/label/null | 0.25.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_vpc_endpoint_policy"></a> [vpc\_endpoint\_policy](#module\_vpc\_endpoint\_policy) | cloudposse/iam-policy/aws | v2.0.1 |
 


### PR DESCRIPTION
## what
- Add Prometheus policy label module for cross-account role

## why
- Labels should be created using the null-label module for consistent formating

## references
- Related comment: https://github.com/cloudposse/terraform-aws-managed-grafana/pull/1#discussion_r1621474600