### PR TITLE
fix: `rule_group_namespaces` `for_each` error and VPC endpoint count dependency

### DIFF
--- a/cross-account-role.tf
+++ b/cross-account-role.tf
@@ -29,11 +29,14 @@ resource "aws_iam_role" "account_access" {
       },
     ]
   })
+}
 
-  inline_policy {
-    name   = module.account_access_policy_label.id
-    policy = data.aws_iam_policy_document.aps[0].json
-  }
+resource "aws_iam_role_policy" "account_access" {
+  count = local.access_role_enabled ? 1 : 0
+
+  name   = module.account_access_policy_label.id
+  role   = aws_iam_role.account_access[0].id
+  policy = data.aws_iam_policy_document.aps[0].json
 }
 
 # See "Amazon Managed Service for Prometheus"

--- a/cross-account-role.tf
+++ b/cross-account-role.tf
@@ -35,8 +35,8 @@ resource "aws_iam_role_policy" "account_access" {
   count = local.access_role_enabled ? 1 : 0
 
   name   = module.account_access_policy_label.id
-  role   = aws_iam_role.account_access[0].id
-  policy = data.aws_iam_policy_document.aps[0].json
+  role   = one(aws_iam_role.account_access[*].id)
+  policy = one(data.aws_iam_policy_document.aps[*].json)
 }
 
 # See "Amazon Managed Service for Prometheus"

--- a/examples/basic/fixtures.us-east-2.tfvars
+++ b/examples/basic/fixtures.us-east-2.tfvars
@@ -7,5 +7,3 @@ environment = "ue2"
 stage = "test"
 
 name = "example"
-
-enabled = true

--- a/examples/basic/fixtures.us-east-2.tfvars
+++ b/examples/basic/fixtures.us-east-2.tfvars
@@ -7,3 +7,5 @@ environment = "ue2"
 stage = "test"
 
 name = "example"
+
+enabled = true

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -7,5 +7,3 @@ environment = "ue2"
 stage = "test"
 
 name = "example"
-
-enabled = true

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -7,3 +7,5 @@ environment = "ue2"
 stage = "test"
 
 name = "example"
+
+enabled = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,7 +10,7 @@ module "managed_prometheus" {
 
   allowed_account_id = data.aws_caller_identity.current.account_id
   scraper_deployed   = true
-  vpc_id             = data.aws_vpc.default[0].id
+  vpc_id             = try(data.aws_vpc.default[0].id, "")
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,8 +1,10 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_vpc" "default" {
-  count   = var.enabled ? 1 : 0
-  default = true
+module "vpc" {
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.2.0"
+  ipv4_primary_cidr_block = "172.16.0.0/20"
+  context                 = module.this.context
 }
 
 module "managed_prometheus" {
@@ -10,7 +12,7 @@ module "managed_prometheus" {
 
   allowed_account_id = data.aws_caller_identity.current.account_id
   scraper_deployed   = true
-  vpc_id             = try(data.aws_vpc.default[0].id, "")
+  vpc_id             = module.vpc.vpc_id
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_vpc" "default" {
+  count   = var.enabled ? 1 : 0
   default = true
 }
 
@@ -9,7 +10,7 @@ module "managed_prometheus" {
 
   allowed_account_id = data.aws_caller_identity.current.account_id
   scraper_deployed   = true
-  vpc_id             = data.aws_vpc.default.id
+  vpc_id             = data.aws_vpc.default[0].id
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,10 +10,10 @@ module "vpc" {
 module "managed_prometheus" {
   source = "../.."
 
-  allowed_account_id    = data.aws_caller_identity.current.account_id
-  scraper_deployed      = true
-  vpc_endpoint_enabled  = true
-  vpc_id                = module.vpc.vpc_id
+  allowed_account_id   = data.aws_caller_identity.current.account_id
+  scraper_deployed     = true
+  vpc_endpoint_enabled = true
+  vpc_id               = module.vpc.vpc_id
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,9 +10,10 @@ module "vpc" {
 module "managed_prometheus" {
   source = "../.."
 
-  allowed_account_id = data.aws_caller_identity.current.account_id
-  scraper_deployed   = true
-  vpc_id             = module.vpc.vpc_id
+  allowed_account_id    = data.aws_caller_identity.current.account_id
+  scraper_deployed      = true
+  vpc_endpoint_enabled  = true
+  vpc_id                = module.vpc.vpc_id
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_prometheus_alert_manager_definition" "this" {
 }
 
 resource "aws_prometheus_rule_group_namespace" "this" {
-  for_each = local.enabled ? toset(var.rule_group_namespaces) : []
+  for_each = local.enabled ? { for idx, namespace in var.rule_group_namespaces : namespace.name => namespace } : {}
 
   name = each.value.name
   data = each.value.data

--- a/variables.tf
+++ b/variables.tf
@@ -25,8 +25,14 @@ variable "allowed_account_id" {
   default     = ""
 }
 
+variable "vpc_endpoint_enabled" {
+  type        = bool
+  description = "Set to true to create a VPC endpoint for Amazon Managed Prometheus. Requires vpc_id to be set."
+  default     = false
+}
+
 variable "vpc_id" {
   type        = string
-  description = "If set, the ID of the VPC in which the endpoint will be used. If not set, no VPC endpoint will be created."
+  description = "If `var.vpc_endpoint_enabled` is true, the ID of the VPC in which the endpoint will be used."
   default     = ""
 }

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -1,39 +1,27 @@
 locals {
-  vpc_endpoint_enabled = local.enabled && try(length(var.vpc_id) > 0, false)
+  # Deploy the VPC endpoint if explicitly enabled
+  vpc_endpoint_enabled = local.enabled && var.vpc_endpoint_enabled
 }
 
 data "aws_region" "current" {}
 
-module "vpc_endpoint_policy" {
-  source  = "cloudposse/iam-policy/aws"
-  version = "2.0.1"
+data "aws_iam_policy_document" "vpc_endpoint_policy" {
+  count = local.vpc_endpoint_enabled ? 1 : 0
 
-  enabled = local.vpc_endpoint_enabled
-
-  iam_policy = [{
-    statements = [
-      {
-        effect    = "Allow"
-        actions   = ["aps:*"]
-        resources = ["*"]
-        principals = [
-          {
-            type        = "AWS"
-            identifiers = ["*"]
-          }
-        ]
-        conditions = [
-          {
-            test     = "StringEquals"
-            variable = "aws:SourceVpc"
-            values   = [var.vpc_id]
-          }
-        ]
-      }
-    ]
-  }]
-
-  context = module.this.context
+  statement {
+    effect    = "Allow"
+    actions   = ["aps:*"]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceVpc"
+      values   = [var.vpc_id]
+    }
+  }
 }
 
 resource "aws_vpc_endpoint" "prometheus" {
@@ -43,7 +31,7 @@ resource "aws_vpc_endpoint" "prometheus" {
   service_name      = format("com.amazonaws.%s.aps-workspaces", data.aws_region.current.id)
   vpc_endpoint_type = "Interface"
 
-  policy = try(module.vpc_endpoint_policy.json, "")
+  policy = data.aws_iam_policy_document.vpc_endpoint_policy[0].json
 
   tags = module.this.tags
 }

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -3,7 +3,9 @@ locals {
   vpc_endpoint_enabled = local.enabled && var.vpc_endpoint_enabled
 }
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+  count = local.vpc_endpoint_enabled ? 1 : 0
+}
 
 data "aws_iam_policy_document" "vpc_endpoint_policy" {
   count = local.vpc_endpoint_enabled ? 1 : 0
@@ -28,10 +30,10 @@ resource "aws_vpc_endpoint" "prometheus" {
   count = local.vpc_endpoint_enabled ? 1 : 0
 
   vpc_id            = var.vpc_id
-  service_name      = format("com.amazonaws.%s.aps-workspaces", data.aws_region.current.region)
+  service_name      = format("com.amazonaws.%s.aps-workspaces", one(data.aws_region.current[*].region))
   vpc_endpoint_type = "Interface"
 
-  policy = data.aws_iam_policy_document.vpc_endpoint_policy[0].json
+  policy = one(data.aws_iam_policy_document.vpc_endpoint_policy[*].json)
 
   tags = module.this.tags
 }

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -8,7 +8,7 @@ module "vpc_endpoint_policy" {
   source  = "cloudposse/iam-policy/aws"
   version = "2.0.1"
 
-  enabled = local.vpc_endpoint_enabled
+  count = local.vpc_endpoint_enabled ? 1 : 0
 
   iam_policy = [{
     statements = [
@@ -43,7 +43,7 @@ resource "aws_vpc_endpoint" "prometheus" {
   service_name      = format("com.amazonaws.%s.aps-workspaces", data.aws_region.current.id)
   vpc_endpoint_type = "Interface"
 
-  policy = module.vpc_endpoint_policy.json
+  policy = try(module.vpc_endpoint_policy[0].json, "")
 
   tags = module.this.tags
 }

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -28,7 +28,7 @@ resource "aws_vpc_endpoint" "prometheus" {
   count = local.vpc_endpoint_enabled ? 1 : 0
 
   vpc_id            = var.vpc_id
-  service_name      = format("com.amazonaws.%s.aps-workspaces", data.aws_region.current.id)
+  service_name      = format("com.amazonaws.%s.aps-workspaces", data.aws_region.current.region)
   vpc_endpoint_type = "Interface"
 
   policy = data.aws_iam_policy_document.vpc_endpoint_policy[0].json

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -1,5 +1,5 @@
 locals {
-  vpc_endpoint_enabled = local.enabled && length(var.vpc_id) > 0
+  vpc_endpoint_enabled = local.enabled && try(length(var.vpc_id) > 0, false)
 }
 
 data "aws_region" "current" {}
@@ -8,7 +8,7 @@ module "vpc_endpoint_policy" {
   source  = "cloudposse/iam-policy/aws"
   version = "2.0.1"
 
-  count = local.vpc_endpoint_enabled ? 1 : 0
+  enabled = local.vpc_endpoint_enabled
 
   iam_policy = [{
     statements = [
@@ -43,7 +43,7 @@ resource "aws_vpc_endpoint" "prometheus" {
   service_name      = format("com.amazonaws.%s.aps-workspaces", data.aws_region.current.id)
   vpc_endpoint_type = "Interface"
 
-  policy = try(module.vpc_endpoint_policy[0].json, "")
+  policy = try(module.vpc_endpoint_policy.json, "")
 
   tags = module.this.tags
 }

--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -40,7 +40,7 @@ resource "aws_vpc_endpoint" "prometheus" {
   count = local.vpc_endpoint_enabled ? 1 : 0
 
   vpc_id            = var.vpc_id
-  service_name      = format("com.amazonaws.%s.aps-workspaces", data.aws_region.current.name)
+  service_name      = format("com.amazonaws.%s.aps-workspaces", data.aws_region.current.id)
   vpc_endpoint_type = "Interface"
 
   policy = module.vpc_endpoint_policy.json


### PR DESCRIPTION
## breaking changes

⚠️ **VPC Endpoint Configuration**: Users who were previously creating VPC endpoints by setting `vpc_id` must now also set `vpc_endpoint_enabled = true` to maintain the same behavior. Previously, setting `vpc_id` automatically created a VPC endpoint. Now, both `vpc_id` and `vpc_endpoint_enabled = true` are required.

**Migration**: Update your module calls to include `vpc_endpoint_enabled = true` when using VPC endpoints:
```
module "managed_prometheus" {
  # ... other configuration ...
  vpc_id               = "vpc-xxxxx"
  vpc_endpoint_enabled = true  # Add this line
}

```
## what

- Replaced `toset(var.rule_group_namespaces)` with a for expression that converts the list into a map keyed by namespace.name
- Changed the empty case from `[]` to `{}` since we're using a map
- Added new `vpc_endpoint_enabled` variable to explicitly control VPC endpoint creation
- Replaced `cloudposse/iam-policy/aws` module with native `aws_iam_policy_document` data source for VPC endpoint policy
- Moved inline policy from `aws_iam_role` to separate `aws_iam_role_policy` resource for cross-account access role

## why

### Rule Group Namespaces Fix
- The map uses name as the key and the full object as the value, so each.value.name and each.value.data continue to work. This should resolve the Terraform error.

```
╷
│ Error: Invalid for_each argument
│
│ on .terraform/modules/managed_prometheus/main.tf line 17, in resource "aws_prometheus_rule_group_namespace" "this":
│ 17: for_each = local.enabled ? toset(var.rule_group_namespaces) : []
│ ├────────────────
│ │ local.enabled is true
│ │ var.rule_group_namespaces is empty list of object
│
│ The given "for_each" argument value is unsuitable: "for_each" supports sets of strings, but you have provided a set containing type object.
╵
```

### VPC Endpoint Enabled Variable
- When `vpc_id` is computed at apply time (e.g., from `module.vpc.vpc_id`), using `length(var.vpc_id) > 0` in count expressions causes Terraform errors because it depends on resource attributes that cannot be determined until apply
- The new `vpc_endpoint_enabled` variable provides explicit control over VPC endpoint creation without depending on computed values, allowing Terraform to determine the count at plan time

### IAM Policy Module Replacement
- Replaced `cloudposse/iam-policy/aws` module with native `aws_iam_policy_document` data source to reduce external dependencies and simplify the codebase
- The native data source provides the same functionality without requiring an additional module dependency

### Separate IAM Role Policy Resource
- Moved inline policy from `aws_iam_role.account_access` to a separate `aws_iam_role_policy` resource
- This follows AWS best practices by separating role and policy management, making it easier to update policies independently and improving resource organization

## references

.