### PR TITLE
fix: Corrected data.aws_region ID

### DIFF
--- a/vpc-endpoint.tf
+++ b/vpc-endpoint.tf
@@ -30,7 +30,7 @@ resource "aws_vpc_endpoint" "prometheus" {
   count = local.vpc_endpoint_enabled ? 1 : 0
 
   vpc_id            = var.vpc_id
-  service_name      = format("com.amazonaws.%s.aps-workspaces", one(data.aws_region.current[*].region))
+  service_name      = format("com.amazonaws.%s.aps-workspaces", one(data.aws_region.current[*].id))
   vpc_endpoint_type = "Interface"
 
   policy = one(data.aws_iam_policy_document.vpc_endpoint_policy[*].json)


### PR DESCRIPTION
## what
- Replaced `data.aws_region.current[*].region` with `data.aws_region.current[*].id`

## why
- This object does not have an attribute named "region".

## references
```
│ Error: Unsupported attribute
│
│   on .terraform/modules/managed_prometheus/vpc-endpoint.tf line 33, in resource "aws_vpc_endpoint" "prometheus":
│   33:   service_name      = format("com.amazonaws.%s.aps-workspaces", one(data.aws_region.current[*].region))
│
│ This object does not have an attribute named "region".
```